### PR TITLE
Missing Char encoding type on socket.write()

### DIFF
--- a/lib/AsteriskAmi.js
+++ b/lib/AsteriskAmi.js
@@ -150,7 +150,7 @@ AsteriskAmi.prototype.send = function(obj, cb) {
   //maybe i should be checking if this socket is writeable
   if(this.socket != null && this.socket.writable){
     this.debug(obj);
-    this.socket.write(this.generateSocketData(obj), 'ascii', cb);
+    this.socket.write(this.generateSocketData(obj), this.ami_encoding, cb);
   }else{
     this.debug('cannot write to Asterisk Socket');
     this.emit('ami_socket_unwritable');


### PR DESCRIPTION
Make socket.write use same encoding as socket.setEncoding, set by params or default.
